### PR TITLE
9 sign up 구현

### DIFF
--- a/config/db.go
+++ b/config/db.go
@@ -29,6 +29,9 @@ func ConnectDB() {
 		panic(err)
 	}
 
-	db.AutoMigrate(&models.Burger{})
+	if db.AutoMigrate(&models.Burger{}, &models.User{}) != nil {
+		log.Fatal("Failed DB auto migration.")
+	}
+
 	DB = db
 }

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -1,7 +1,43 @@
 package controllers
 
-import "github.com/gin-gonic/gin"
+import (
+	"github.com/gin-gonic/gin"
+	"golang.org/x/crypto/bcrypt"
+	"pian-gin/config"
+	"pian-gin/models"
+)
 
 func SignUp(c *gin.Context) {
+	var body struct {
+		Name     string
+		Email    string
+		Password string
+	}
 
+	if c.Bind(&body) != nil {
+		c.JSON(400, gin.H{
+			"error": "Failed to read body",
+		})
+
+		return
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(body.Password), 10)
+
+	if err != nil {
+		c.JSON(400, err)
+
+		return
+	}
+
+	user := models.User{Email: body.Email, Password: string(hash)}
+	result := config.DB.Create(&user)
+
+	if result.Error != nil {
+		c.JSON(400, result.Error)
+
+		return
+	}
+
+	c.JSON(200, &user)
 }

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -1,0 +1,7 @@
+package controllers
+
+import "github.com/gin-gonic/gin"
+
+func SignUp(c *gin.Context) {
+
+}

--- a/main.go
+++ b/main.go
@@ -11,5 +11,6 @@ func main() {
 	r := gin.Default()
 	config.ConnectDB()
 	routes.BurgerRoute(r)
+	routes.UserRouter(r)
 	log.Fatal(r.Run(":8081"))
 }

--- a/models/user.go
+++ b/models/user.go
@@ -1,0 +1,11 @@
+package models
+
+import "gorm.io/gorm"
+
+type User struct {
+	gorm.Model
+	ID       uint `gorm:"primary_key"`
+	Name     string
+	Email    string `gorm:"unique"`
+	Password string
+}

--- a/routes/user.go
+++ b/routes/user.go
@@ -1,0 +1,10 @@
+package routes
+
+import (
+	"github.com/gin-gonic/gin"
+	"pian-gin/controllers"
+)
+
+func UserRouter(router *gin.Engine) {
+	router.POST("/user", controllers.SignUp)
+}


### PR DESCRIPTION
- user model과 sign up 로직을 구현.
- user model의 'email' column에 unique 옵션을 넣어 중복된 이메일로 가입 방지.
- email을 bcrypt를 통해 암호화.
- user router를 마련하고 SignUp 핸들러와 '/user' 라우트의 POST 요청에 대응하도록 연결.